### PR TITLE
added btnIconFillMode to allow adding icons for the buttons which do …

### DIFF
--- a/src/InputPanelIface.cpp
+++ b/src/InputPanelIface.cpp
@@ -6,6 +6,7 @@ struct InputPanelIface::InputPanelIfacePrivate {
     QColor btnSpecialBackgroundColor{};
     QColor btnTextColor{};
     int btnRadius{};
+    int btnIconFillMode{};
     QString btnTextFontFamily{};
     QString backspaceIcon{};
     QString enterIcon{};
@@ -75,6 +76,15 @@ void InputPanelIface::setBtnRadius(const int btnRadius) {
     if (pimpl->btnRadius != btnRadius) {
         pimpl->btnRadius = btnRadius;
         emit btnRadiusChanged();
+    }
+}
+
+int InputPanelIface::btnIconFillMode() const { return pimpl->btnIconFillMode; }
+
+void InputPanelIface::setBtnIconFillMode(const int btnIconFillMode) {
+    if (pimpl->btnIconFillMode != btnIconFillMode) {
+        pimpl->btnIconFillMode = btnIconFillMode;
+        emit btnIconFillModeChanged();
     }
 }
 

--- a/src/InputPanelIface.hpp
+++ b/src/InputPanelIface.hpp
@@ -17,6 +17,7 @@ class InputPanelIface : public QObject {
     Q_PROPERTY(QColor btnSpecialBackgroundColor READ btnSpecialBackgroundColor WRITE setBtnSpecialBackgroundColor NOTIFY btnSpecialBackgroundColorChanged)
     Q_PROPERTY(QColor btnTextColor READ btnTextColor WRITE setBtnTextColor NOTIFY btnTextColorChanged)
     Q_PROPERTY(int btnRadius READ btnRadius WRITE setBtnRadius NOTIFY btnRadiusChanged)
+    Q_PROPERTY(int btnIconFillMode READ btnIconFillMode WRITE setBtnIconFillMode NOTIFY btnIconFillModeChanged)
     Q_PROPERTY(QString btnTextFontFamily READ btnTextFontFamily WRITE setBtnTextFontFamily NOTIFY btnTextFontFamilyChanged)
     Q_PROPERTY(QString backspaceIcon READ backspaceIcon WRITE setBackspaceIcon NOTIFY backspaceIconChanged)
     Q_PROPERTY(QString enterIcon READ enterIcon WRITE setEnterIcon NOTIFY enterIconChanged)
@@ -46,6 +47,9 @@ class InputPanelIface : public QObject {
 
     int btnRadius() const;
     void setBtnRadius(const int btnRadius);
+
+    int btnIconFillMode() const;
+    void setBtnIconFillMode(int btnIconFillMode);
 
     QString btnTextFontFamily() const;
     void setBtnTextFontFamily(const QString &btnTextFontFamily);
@@ -81,6 +85,7 @@ class InputPanelIface : public QObject {
     void btnSpecialBackgroundColorChanged();
     void btnTextColorChanged();
     void btnRadiusChanged();
+    void btnIconFillModeChanged();
     void btnTextFontFamilyChanged();
     void backspaceIconChanged();
     void enterIconChanged();

--- a/src/qml/InputPanel.qml
+++ b/src/qml/InputPanel.qml
@@ -11,6 +11,7 @@ Item {
     property color btnSpecialBackgroundColor: Qt.darker("#808080")
     property color btnTextColor: "#ffffff"
     property int btnRadius: 0
+    property int btnIconFillMode: Image.PreserveAspectFit
     property string btnTextFontFamily
     property string languageLayout: "En"
     property string backspaceIcon: "qrc:/icons/backspace.png"
@@ -77,6 +78,7 @@ Item {
         InputPanel.btnSpecialBackgroundColor = btnSpecialBackgroundColor;
         InputPanel.btnTextColor = btnTextColor;
         InputPanel.btnRadius = btnRadius;
+        InputPanel.btnIconFillMode = btnIconFillMode;
         InputPanel.btnTextFontFamily = btnTextFontFamily;
         InputPanel.backspaceIcon = backspaceIcon;
         InputPanel.enterIcon = enterIcon;

--- a/src/qml/Key.qml
+++ b/src/qml/Key.qml
@@ -12,6 +12,7 @@ Button {
     property int btnKey: Qt.Key_unknown
     property color btnBackground: InputPanel.btnBackgroundColor
     property int btnRadius: InputPanel.btnRadius
+    property int btnIconFillMode: InputPanel.btnIconFillMode
     property color txtColor: InputPanel.btnTextColor
     property string txtFont: InputPanel.btnTextFontFamily
     property string btnIcon: ""
@@ -74,7 +75,7 @@ Button {
         Text {
             id: btnTextItem
 
-            text: btnDisplayedText == "" ? btnText : btnDisplayedText
+            text: btnDisplayedText === "" ? btnText : btnDisplayedText
             color: txtColor
             anchors.fill: parent
             horizontalAlignment: Text.AlignHCenter
@@ -86,18 +87,14 @@ Button {
                 pixelSize: key.height * 0.4
                 capitalization: InputEngine.uppercase ? Font.AllUppercase : Font.MixedCase
             }
-
         }
-
         Image {
             id: btnIconItem
-
             source: btnIcon
             visible: btnDisplayedText === ""
             anchors.fill: parent
-            fillMode: Image.PreserveAspectFit
+            fillMode: btnIconFillMode
         }
-
     }
 
 }


### PR DESCRIPTION
 Added btnIconFillMode to InputPanel so that the fillMode for the icon of the Key is customizable. With Image.Pad it is possible to use icons which keep their original size and don't scale to the size of the key.