### PR TITLE
Add keyboardSideMargin for setting margins for the layouts of the key…

### DIFF
--- a/src/qml/InputPanel.qml
+++ b/src/qml/InputPanel.qml
@@ -21,6 +21,7 @@ Item {
     property string hideKeyboardIcon: "qrc:/icons/hide-arrow.png"
     property string languageIcon: "qrc:/icons/language.png"
     property var availableLanguageLayouts: ["En"]
+    property int keyboardSideMargin: 5
 
     /*! \internal */
     readonly property bool __isRootItem: inputPanel.parent !== null && inputPanel.parent.parent === null
@@ -138,7 +139,10 @@ Item {
 
             anchors {
                 fill: parent
-                margins: 5
+                topMargin: 5
+                bottomMargin: 5
+                leftMargin: root.keyboardSideMargin
+                rightMargin: root.keyboardSideMargin
             }
 
         }


### PR DESCRIPTION
Add keyboardSideMargin for setting margins for the layouts of the keyboard to left and right

![Screenshot from 2025-01-22 10-48-56](https://github.com/user-attachments/assets/cf9d3cb5-f101-486d-8a66-a72c16170d44)
